### PR TITLE
Remove references to 'java' plugin

### DIFF
--- a/samples/code/build-2.gradle
+++ b/samples/code/build-2.gradle
@@ -1,6 +1,5 @@
 // tag::add-gretty[]
 plugins {
-    id 'java'
     id 'war'
     id 'org.akhikhl.gretty' version '1.4.2' // <1>
 }

--- a/samples/code/build-3.gradle
+++ b/samples/code/build-3.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'war'
     id 'org.akhikhl.gretty' version '1.4.2' // <1>
 }

--- a/samples/code/webdemo/build.gradle
+++ b/samples/code/webdemo/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'war'  // <1>
 }
 


### PR DESCRIPTION
Gradle's 'war' plugin extends the 'java' plugin, so there's noneed to explicitly include it in the build examples.

See Issue #7 .